### PR TITLE
Add Autotag & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Autotag and Release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pantheon-systems/action-autotag@v0
+        with:
+          gh-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ with:
   test-versions: 7.4-
   paths: ${{ github.workspace }}/src
 ```
+
+## Development
+
+### Autotag
+This project uses our [autotag action](https://github.com/pantheon-systems/action-autotag). New releases are created on each merge to `main`. See the [autotag readme](https://github.com/pantheon-systems/autotag?tab=readme-ov-file#usage) for details.


### PR DESCRIPTION
* I converted the v1 tag Kevin created to v1.0.0 and pushed instead a `v1` branch that matches main
* Added autotag action to create tags & update v1 branch on each push
* Added dependabot from #5