### PR TITLE
add input "extensions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Select the test versions to run PHPCompatibility. It supports any format accepte
 
 Paths to run compatibility check on. Default: `${{ github.workspace }}`
 
+### extensions
+
+Specify the extensions of the files that will be checked. Example: `extensions: php,inc,lib`. By default, it uses the options set by PHPCompatibility and PHP_CodeSniffer.
+
 ## Example Usage
 
 ```
@@ -31,6 +35,7 @@ uses: pantheon-systems/phpcompatibility-action@v1
 with:
   test-versions: 7.4-
   paths: ${{ github.workspace }}/src
+  extensions: php
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ uses: pantheon-systems/phpcompatibility-action@v1
 with:
   test-versions: 7.4-
   paths: ${{ github.workspace }}/src
-  extensions: php
+  extensions: 'php,inc'
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Skip PHP Setup (useful if it was setup in another step)'
     required: false
     default: 'false'
+  extensions:
+    descriptions: 'Files only with this extension(s) will be tested'
+    required: false,
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -29,3 +33,4 @@ runs:
       env:
         TEST_VERSIONS: ${{ inputs.test-versions }}
         PATHS: ${{ inputs.paths }}
+        EXTENSIONS: ${{ inputs.extensions }}

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   extensions:
     descriptions: 'Files only with this extension(s) will be tested'
     required: false,
-    default: ''
+    default: 'php'
 runs:
   using: 'composite'
   steps:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ composer install
 
 export PATH=$PATH:$GITHUB_ACTION_PATH/vendor/bin
 
-./vendor/bin/phpcs $PATHS --standard=PHPCompatibility --runtime-set testVersion $TEST_VERSIONS
+./vendor/bin/phpcs ${EXTENSIONS:+"--extensions=$EXTENSIONS"} $PATHS --standard=PHPCompatibility --runtime-set testVersion $TEST_VERSIONS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ composer install
 
 export PATH=$PATH:$GITHUB_ACTION_PATH/vendor/bin
 
-./vendor/bin/phpcs ${EXTENSIONS:+"--extensions=$EXTENSIONS"} $PATHS --standard=PHPCompatibility --runtime-set testVersion $TEST_VERSIONS
+./vendor/bin/phpcs --extensions=$EXTENSIONS $PATHS --standard=PHPCompatibility --runtime-set testVersion $TEST_VERSIONS


### PR DESCRIPTION
Add support for `extensions` input  which is passed to phpcs  so that it only checks files of that specific type. I was getting false positive reports of `js` files being minified. I thought, why check `js` files at all? 